### PR TITLE
Feature/historico questoes

### DIFF
--- a/app/public/assets/css/pages/dashboard.css
+++ b/app/public/assets/css/pages/dashboard.css
@@ -356,12 +356,42 @@
     gap: 16px;
 }
 
+.lateral-card-topo {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
 .lateral-titulo {
     font-family: var(--font-heading);
     font-size: 14px;
     font-weight: 700;
     color: var(--white);
     margin: 0;
+}
+
+.lateral-titulo--link {
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+
+.lateral-titulo--link:hover {
+    color: var(--amber-500);
+}
+
+.historico-ver-todas {
+    font-family: var(--font-body);
+    font-size: 12px;
+    color: var(--amber-500);
+    text-decoration: none;
+    white-space: nowrap;
+    transition: opacity 0.2s ease;
+}
+
+.historico-ver-todas:hover {
+    opacity: 0.75;
+    text-decoration: underline;
 }
 
 .historico-tabela {

--- a/app/public/assets/css/pages/historicoQuestoes.css
+++ b/app/public/assets/css/pages/historicoQuestoes.css
@@ -1,0 +1,309 @@
+@import url("../global.css");
+
+/* content.css tem svg { width:200px; height:200px }.
+   [hidden] precisa de !important para não ser sobrescrito
+   por regras de display das classes (ex: display:flex em .certificado-lock). */
+[hidden] { display: none !important; }
+
+/* ================================
+   FIX: content.css define svg { width: 200px; height: 200px; }
+   que afeta os ícones da sidebar e dos cards.
+   Aqui sobrescrevemos esse reset para os SVGs do dashboard.
+   ================================ */
+
+.sidebar-link svg,
+.nivel-indicador svg,
+.certificado-lock svg,
+.cert-liberado-badge svg {
+    width: unset;
+    height: unset;
+}
+
+/* Garante que os blobs fiquem atrás do layout */
+.blob-esquerda,
+.blob-direita {
+    z-index: 0;
+}
+
+/* ================================
+   WRAPPER GERAL (sidebar + main)
+   ================================ */
+
+.dashboard-wrapper {
+    display: flex;
+    min-height: 100vh;
+    padding-top: 64px;
+    position: relative;
+    z-index: 1;
+}
+
+/* ================================
+   SIDEBAR
+   ================================ */
+
+.sidebar {
+    width: 160px;
+    flex-shrink: 0;
+    background-color: var(--navy-800);
+    border-right: 1px solid var(--navy-700);
+    padding: 24px 0;
+    position: fixed;
+    top: 64px;
+    left: 0;
+    height: calc(100vh - 64px);
+    display: flex;
+    flex-direction: column;
+    z-index: 10;
+}
+
+.sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 0 12px;
+}
+
+.sidebar-link {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 9px 12px;
+    border-radius: 8px;
+    font-family: var(--font-heading);
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--slate-400);
+    text-decoration: none;
+    text-transform: uppercase;
+    letter-spacing: 0.7px;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.sidebar-link svg {
+    flex-shrink: 0;
+    opacity: 0.6;
+}
+
+.sidebar-link:hover {
+    background-color: var(--navy-700);
+    color: var(--white);
+}
+
+.sidebar-link--ativo {
+    color: var(--white);
+    background-color: var(--navy-700);
+}
+
+.sidebar-link--ativo svg {
+    opacity: 1;
+    color: var(--amber-500);
+}
+
+/* ================================
+   LATERAL
+   ================================ */
+   
+.dashboard-lateral {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    position: sticky;
+    top: calc(64px + 36px);
+}
+
+.lateral-card {
+    background-color: var(--navy-800);
+    border: 1px solid var(--navy-700);
+    border-radius: 14px;
+    padding: 22px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.lateral-titulo {
+    font-family: var(--font-heading);
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--white);
+    margin: 0;
+}
+
+.historico-tabela {
+    width: 100%;
+    border-collapse: collapse;
+    font-family: var(--font-body);
+    font-size: 12px;
+}
+
+.historico-tabela th {
+    color: var(--slate-400);
+    font-weight: 600;
+    text-align: left;
+    padding: 4px 6px 8px;
+    border-bottom: 1px solid var(--navy-700);
+}
+
+.historico-tabela td {
+    color: var(--navy-200);
+    padding: 8px 6px;
+    border-bottom: 1px solid rgba(22, 43, 92, 0.6);
+}
+
+.historico-tabela tr:last-child td {
+    border-bottom: none;
+}
+
+.pontuacao {
+    font-weight: 700;
+}
+
+.pontuacao--verde   { color: var(--teal-500); }
+.pontuacao--vermelho { color: var(--red-500); }
+.pontuacao--amarelo  { color: var(--amber-500); }
+
+.historico-link {
+    font-family: var(--font-body);
+    font-size: 12px;
+    color: var(--amber-500);
+    text-decoration: none;
+    transition: opacity 0.2s;
+    align-self: flex-start;
+}
+
+.historico-link:hover {
+    opacity: 0.75;
+    text-decoration: underline;
+}
+
+.lateral-card--certificado {
+    align-items: center;
+    text-align: center;
+}
+
+.certificado-icone {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 80px;
+    height: 80px;
+    background-color: var(--navy-700);
+    border: 1px solid var(--navy-600);
+    border-radius: 16px;
+    margin: 0 auto;
+}
+
+.certificado-lock {
+    color: var(--slate-600);
+    display: flex;
+    justify-content: center;
+}
+
+.certificado-descricao {
+    font-family: var(--font-body);
+    font-size: 12px;
+    color: var(--slate-400);
+    margin: 0;
+    line-height: 1.6;
+}
+
+.certificado-progresso {
+    font-family: var(--font-body);
+    font-size: 11px;
+    color: var(--slate-600);
+}
+
+.lateral-card--certificado-liberado {
+    border-color: rgba(245, 158, 11, 0.45);
+    box-shadow: 0 0 24px rgba(245, 158, 11, 0.1);
+}
+
+.cert-liberado-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: rgba(245, 158, 11, 0.12);
+    border: 1px solid rgba(245, 158, 11, 0.4);
+    border-radius: 20px;
+    padding: 5px 14px;
+    font-family: var(--font-heading);
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--amber-400);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+/* ================================
+   NAV LINK ATIVO
+   ================================ */
+
+.nav-link--ativo {
+    color: var(--amber-500) !important;
+}
+
+/* ================================
+   RESPONSIVO
+   ================================ */
+
+@media (max-width: 1024px) {
+    .dashboard-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .dashboard-lateral {
+        position: static;
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+
+    .lateral-card {
+        flex: 1;
+        min-width: 260px;
+    }
+}
+
+@media (max-width: 768px) {
+    .sidebar {
+        display: none;
+    }
+
+    .dashboard-main {
+        margin-left: 0;
+        padding: 24px 20px 48px;
+    }
+}
+
+@media (max-width: 600px) {
+    .nivel-cabecalho {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 6px;
+    }
+
+    .nivel-meta {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .dashboard-lateral {
+        flex-direction: column;
+    }
+}
+/* ================================
+   NAVBAR: saudação + sair em linha
+   ================================ */
+
+@media (min-width: 481px) {
+    .nav-menu {
+        flex-direction: row;
+        gap: 32px;
+    }
+}
+
+#nav-logado {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    white-space: nowrap;
+}

--- a/app/public/assets/css/pages/historicoQuestoes.css
+++ b/app/public/assets/css/pages/historicoQuestoes.css
@@ -1,32 +1,19 @@
 @import url("../global.css");
 
-/* content.css tem svg { width:200px; height:200px }.
-   [hidden] precisa de !important para não ser sobrescrito
-   por regras de display das classes (ex: display:flex em .certificado-lock). */
 [hidden] { display: none !important; }
 
-/* ================================
-   FIX: content.css define svg { width: 200px; height: 200px; }
-   que afeta os ícones da sidebar e dos cards.
-   Aqui sobrescrevemos esse reset para os SVGs do dashboard.
-   ================================ */
-
-.sidebar-link svg,
-.nivel-indicador svg,
-.certificado-lock svg,
-.cert-liberado-badge svg {
+.sidebar-link svg {
     width: unset;
     height: unset;
 }
 
-/* Garante que os blobs fiquem atrás do layout */
 .blob-esquerda,
 .blob-direita {
     z-index: 0;
 }
 
 /* ================================
-   WRAPPER GERAL (sidebar + main)
+   WRAPPER
    ================================ */
 
 .dashboard-wrapper {
@@ -38,7 +25,7 @@
 }
 
 /* ================================
-   SIDEBAR
+   SIDEBAR FIXA (nav de páginas)
    ================================ */
 
 .sidebar {
@@ -100,166 +87,423 @@
 }
 
 /* ================================
-   LATERAL
+   MAIN (área de conteúdo)
    ================================ */
-   
-.dashboard-lateral {
+
+.historico-main {
+    flex: 1;
+    margin-left: 160px;
+    min-height: 100vh;
+}
+
+.historico-container {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 40px 48px 64px;
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+}
+
+/* ================================
+   HEADER DA PÁGINA
+   ================================ */
+
+.historico-header {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.historico-titulo {
+    font-family: var(--font-heading);
+    font-size: 32px;
+    font-weight: 700;
+    color: var(--white);
+    margin: 0;
+    line-height: 1.2;
+}
+
+.historico-destaque {
+    color: var(--amber-500);
+}
+
+.historico-subtitulo {
+    font-family: var(--font-body);
+    font-size: 15px;
+    color: var(--slate-400);
+    margin: 0;
+}
+
+/* ================================
+   LAYOUT (sidebar módulos + painel)
+   ================================ */
+
+.historico-layout {
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    gap: 28px;
+    align-items: start;
+}
+
+/* ================================
+   SIDEBAR DE MÓDULOS (interna)
+   ================================ */
+
+.historico-sidebar {
+    background-color: var(--navy-800);
+    border: 1px solid var(--navy-600);
+    border-radius: 20px;
+    padding: 24px;
+    position: sticky;
+    top: calc(64px + 24px);
+    max-height: calc(100vh - 64px - 48px);
+    overflow-y: auto;
     display: flex;
     flex-direction: column;
     gap: 20px;
-    position: sticky;
-    top: calc(64px + 36px);
 }
 
-.lateral-card {
-    background-color: var(--navy-800);
-    border: 1px solid var(--navy-700);
-    border-radius: 14px;
-    padding: 22px 20px;
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-}
-
-.lateral-titulo {
+.historico-sidebar-titulo {
     font-family: var(--font-heading);
-    font-size: 14px;
-    font-weight: 700;
+    font-size: 18px;
+    font-weight: 600;
     color: var(--white);
     margin: 0;
 }
 
-.historico-tabela {
-    width: 100%;
-    border-collapse: collapse;
-    font-family: var(--font-body);
-    font-size: 12px;
-}
-
-.historico-tabela th {
-    color: var(--slate-400);
-    font-weight: 600;
-    text-align: left;
-    padding: 4px 6px 8px;
-    border-bottom: 1px solid var(--navy-700);
-}
-
-.historico-tabela td {
-    color: var(--navy-200);
-    padding: 8px 6px;
-    border-bottom: 1px solid rgba(22, 43, 92, 0.6);
-}
-
-.historico-tabela tr:last-child td {
-    border-bottom: none;
-}
-
-.pontuacao {
-    font-weight: 700;
-}
-
-.pontuacao--verde   { color: var(--teal-500); }
-.pontuacao--vermelho { color: var(--red-500); }
-.pontuacao--amarelo  { color: var(--amber-500); }
-
-.historico-link {
-    font-family: var(--font-body);
-    font-size: 12px;
-    color: var(--amber-500);
-    text-decoration: none;
-    transition: opacity 0.2s;
-    align-self: flex-start;
-}
-
-.historico-link:hover {
-    opacity: 0.75;
-    text-decoration: underline;
-}
-
-.lateral-card--certificado {
-    align-items: center;
-    text-align: center;
-}
-
-.certificado-icone {
+.historico-sidebar-lista {
     display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 80px;
-    height: 80px;
-    background-color: var(--navy-700);
-    border: 1px solid var(--navy-600);
-    border-radius: 16px;
-    margin: 0 auto;
+    flex-direction: column;
+    gap: 12px;
 }
 
-.certificado-lock {
-    color: var(--slate-600);
-    display: flex;
-    justify-content: center;
-}
-
-.certificado-descricao {
+.sidebar-vazio {
     font-family: var(--font-body);
-    font-size: 12px;
+    font-size: 13px;
     color: var(--slate-400);
     margin: 0;
     line-height: 1.6;
 }
 
-.certificado-progresso {
-    font-family: var(--font-body);
-    font-size: 11px;
-    color: var(--slate-600);
+/* ================================
+   ITEM DE MÓDULO NA SIDEBAR
+   ================================ */
+
+.historico-modulo-item {
+    width: 100%;
+    background-color: var(--navy-900);
+    border: 1px solid var(--navy-600);
+    border-radius: 14px;
+    padding: 16px;
+    cursor: pointer;
+    text-align: left;
+    transition: border-color 0.2s ease, transform 0.2s ease;
 }
 
-.lateral-card--certificado-liberado {
-    border-color: rgba(245, 158, 11, 0.45);
-    box-shadow: 0 0 24px rgba(245, 158, 11, 0.1);
+.historico-modulo-item:hover {
+    border-color: var(--amber-500);
+    transform: translateY(-2px);
 }
 
-.cert-liberado-badge {
-    display: inline-flex;
-    align-items: center;
+.historico-modulo-item--ativo {
+    border-color: var(--amber-500);
+}
+
+.historico-modulo-info {
+    display: flex;
+    flex-direction: column;
     gap: 6px;
-    background: rgba(245, 158, 11, 0.12);
-    border: 1px solid rgba(245, 158, 11, 0.4);
-    border-radius: 20px;
-    padding: 5px 14px;
+}
+
+.historico-modulo-titulo {
     font-family: var(--font-heading);
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--white);
+}
+
+.historico-modulo-nota {
+    font-family: var(--font-body);
     font-size: 12px;
-    font-weight: 700;
-    color: var(--amber-400);
+    color: var(--slate-400);
+}
+
+.historico-modulo-item--aprovado .historico-modulo-nota {
+    color: var(--teal-500);
+}
+
+.historico-modulo-item--reprovado .historico-modulo-nota {
+    color: var(--red-500);
+}
+
+/* ================================
+   PAINEL PRINCIPAL
+   ================================ */
+
+.historico-painel {
+    background-color: var(--navy-800);
+    border: 1px solid var(--navy-600);
+    border-radius: 20px;
+    padding: 32px;
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
+    min-width: 0;
+}
+
+.painel-topo {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 24px;
+}
+
+.painel-badge {
+    display: inline-flex;
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-family: var(--font-heading);
+    font-size: 11px;
+    font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
 }
 
+.painel-badge--aprovado {
+    background-color: rgba(13, 148, 136, 0.12);
+    border: 1px solid rgba(13, 148, 136, 0.3);
+    color: var(--teal-500);
+}
+
+.painel-badge--reprovado {
+    background-color: rgba(239, 68, 68, 0.1);
+    border: 1px solid rgba(239, 68, 68, 0.3);
+    color: var(--red-500);
+}
+
+.painel-titulo {
+    font-family: var(--font-heading);
+    font-size: 26px;
+    font-weight: 700;
+    color: var(--white);
+    margin: 12px 0 0;
+}
+
+.painel-resultado {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 4px;
+    flex-shrink: 0;
+}
+
+.painel-resultado span {
+    font-family: var(--font-body);
+    font-size: 12px;
+    color: var(--slate-400);
+}
+
+.painel-resultado strong {
+    font-family: var(--font-heading);
+    font-size: 28px;
+    color: var(--amber-500);
+}
+
 /* ================================
-   NAV LINK ATIVO
+   ESTADOS (carregando / erro / vazio)
+   ================================ */
+
+.painel-mensagem {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 20px;
+    padding: 60px 32px;
+    text-align: center;
+}
+
+.painel-mensagem p {
+    font-family: var(--font-body);
+    font-size: 15px;
+    color: var(--slate-400);
+    margin: 0;
+}
+
+/* ================================
+   LISTA DE QUESTÕES
+   ================================ */
+
+.questoes-lista {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.questao-card {
+    background-color: var(--navy-900);
+    border: 1px solid var(--navy-600);
+    border-left-width: 3px;
+    border-radius: 14px;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.questao-card--correta {
+    border-left-color: var(--teal-500);
+}
+
+.questao-card--errada {
+    border-left-color: var(--red-500);
+}
+
+.questao-topo {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.questao-numero {
+    font-family: var(--font-heading);
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--slate-400);
+    background-color: var(--navy-800);
+    border: 1px solid var(--navy-600);
+    border-radius: 8px;
+    padding: 4px 10px;
+    flex-shrink: 0;
+}
+
+.questao-tag {
+    font-family: var(--font-heading);
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 4px 10px;
+    border-radius: 999px;
+}
+
+.questao-tag--correta {
+    background-color: rgba(13, 148, 136, 0.12);
+    border: 1px solid rgba(13, 148, 136, 0.3);
+    color: var(--teal-500);
+}
+
+.questao-tag--errada {
+    background-color: rgba(239, 68, 68, 0.1);
+    border: 1px solid rgba(239, 68, 68, 0.3);
+    color: var(--red-500);
+}
+
+.questao-enunciado {
+    font-family: var(--font-body);
+    font-size: 15px;
+    line-height: 1.7;
+    color: var(--navy-200);
+    margin: 0;
+}
+
+/* ================================
+   ALTERNATIVAS
+   ================================ */
+
+.questao-opcoes {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.opcao {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px 16px;
+    border-radius: 10px;
+    border: 1px solid var(--navy-600);
+    background-color: var(--navy-800);
+}
+
+.opcao-letra {
+    font-family: var(--font-heading);
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--slate-400);
+    width: 20px;
+    flex-shrink: 0;
+    line-height: 1.6;
+}
+
+.opcao-texto {
+    font-family: var(--font-body);
+    font-size: 14px;
+    line-height: 1.6;
+    color: var(--navy-200);
+}
+
+/* Usuário escolheu e acertou */
+.opcao--escolhida-correta {
+    background-color: rgba(13, 148, 136, 0.12);
+    border-color: var(--teal-500);
+}
+
+.opcao--escolhida-correta .opcao-letra,
+.opcao--escolhida-correta .opcao-texto {
+    color: var(--teal-500);
+}
+
+/* Usuário escolheu mas errou */
+.opcao--escolhida-errada {
+    background-color: rgba(239, 68, 68, 0.1);
+    border-color: var(--red-500);
+}
+
+.opcao--escolhida-errada .opcao-letra,
+.opcao--escolhida-errada .opcao-texto {
+    color: var(--red-500);
+}
+
+/* Resposta correta que o usuário não escolheu (gabarito) */
+.opcao--gabarito {
+    border-color: var(--teal-500);
+}
+
+.opcao--gabarito .opcao-letra,
+.opcao--gabarito .opcao-texto {
+    color: var(--teal-500);
+}
+
+/* ================================
+   NAVBAR
    ================================ */
 
 .nav-link--ativo {
     color: var(--amber-500) !important;
 }
 
+#nav-logado {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    white-space: nowrap;
+}
+
 /* ================================
    RESPONSIVO
    ================================ */
 
-@media (max-width: 1024px) {
-    .dashboard-layout {
+@media (max-width: 980px) {
+    .historico-layout {
         grid-template-columns: 1fr;
     }
 
-    .dashboard-lateral {
+    .historico-sidebar {
         position: static;
-        flex-direction: row;
-        flex-wrap: wrap;
-    }
-
-    .lateral-card {
-        flex: 1;
-        min-width: 260px;
+        max-height: none;
     }
 }
 
@@ -268,42 +512,34 @@
         display: none;
     }
 
-    .dashboard-main {
+    .historico-main {
         margin-left: 0;
+    }
+
+    .historico-container {
         padding: 24px 20px 48px;
     }
 }
 
-@media (max-width: 600px) {
-    .nivel-cabecalho {
+@media (max-width: 640px) {
+    .historico-titulo {
+        font-size: 24px;
+    }
+
+    .historico-painel {
+        padding: 20px;
+    }
+
+    .painel-topo {
         flex-direction: column;
+        gap: 12px;
+    }
+
+    .painel-resultado {
         align-items: flex-start;
-        gap: 6px;
     }
 
-    .nivel-meta {
-        flex-direction: column;
-        align-items: flex-start;
+    .questao-card {
+        padding: 16px;
     }
-
-    .dashboard-lateral {
-        flex-direction: column;
-    }
-}
-/* ================================
-   NAVBAR: saudação + sair em linha
-   ================================ */
-
-@media (min-width: 481px) {
-    .nav-menu {
-        flex-direction: row;
-        gap: 32px;
-    }
-}
-
-#nav-logado {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    white-space: nowrap;
 }

--- a/app/public/assets/js/dashboard.js
+++ b/app/public/assets/js/dashboard.js
@@ -178,7 +178,20 @@ async function carregarHistorico() {
       return;
     }
 
-    corpo.innerHTML = tentativas.map(gerarLinhaHistorico).join("");
+    // mantém apenas a melhor nota por módulo
+    var melhores = new Map();
+    tentativas.forEach(function(t) {
+      var id = Number(t.id_modulo);
+      var existente = melhores.get(id);
+      if (!existente || Number(t.nota) > Number(existente.nota)) {
+        melhores.set(id, t);
+      }
+    });
+
+    var melhoresList = Array.from(melhores.values())
+      .sort(function(a, b) { return Number(a.id_modulo) - Number(b.id_modulo); });
+
+    corpo.innerHTML = melhoresList.map(gerarLinhaHistorico).join("");
   } catch (error) {
     console.error("Erro ao carregar histórico:", error);
     corpo.innerHTML = `<tr><td colspan="3" style="color:var(--slate-400);text-align:center;padding:8px 0">Erro ao carregar.</td></tr>`;

--- a/app/public/assets/js/historicoQuestoes.js
+++ b/app/public/assets/js/historicoQuestoes.js
@@ -1,0 +1,249 @@
+// ================================
+//   HISTORICO QUESTOES - ScrumFlow
+// ================================
+
+if (!estaAutenticado()) {
+  window.location.href = "index.html";
+}
+
+var moduloSelecionado = null;
+var respondidos = [];
+
+var sidebarLista = document.getElementById("sidebar-lista");
+var historicoPainel = document.getElementById("historico-painel");
+
+inicializar();
+
+async function inicializar() {
+  configurarNavbar();
+  await carregarDados();
+}
+
+function configurarNavbar() {
+  var saudacao = document.getElementById("nav-saudacao");
+  var btnSair = document.getElementById("btn-sair");
+  var nome = obterNome();
+
+  if (saudacao && nome) {
+    saudacao.textContent = "Olá, " + nome;
+  }
+
+  if (btnSair) {
+    btnSair.addEventListener("click", function() {
+      limparSessao();
+      window.location.href = "index.html";
+    });
+  }
+}
+
+async function carregarDados() {
+  try {
+    renderizarPainelCarregando();
+
+    var resModulos = await apiFetch("/api/questoes/modulos");
+    var resRespondidos = await apiFetch("/api/questoes/modulos-respondidos");
+
+    if (!resModulos || !resRespondidos) return;
+
+    var dadosModulos = await resModulos.json();
+    var dadosRespondidos = await resRespondidos.json();
+
+    // mapa id_modulo → titulo vindo do banco
+    var titulosMap = new Map(
+      dadosModulos.map(function(m) {
+        return [Number(m.id_modulo), m.titulo];
+      })
+    );
+
+    // agrupa por módulo mantendo apenas a última tentativa (maior número de tentativa)
+    var mapaRespondidos = new Map();
+    dadosRespondidos.forEach(function(item) {
+      var id = Number(item.id_modulo);
+      var existente = mapaRespondidos.get(id);
+      if (!existente || Number(item.tentativa) > Number(existente.tentativa)) {
+        mapaRespondidos.set(id, item);
+      }
+    });
+
+    respondidos = Array.from(mapaRespondidos.values())
+      .map(function(item) {
+        return {
+          id_modulo: Number(item.id_modulo),
+          titulo: titulosMap.get(Number(item.id_modulo)) || "Módulo " + item.id_modulo,
+          nota: Number(item.nota),
+          questoes: Number(item.questoes),
+          tentativa: Number(item.tentativa),
+        };
+      })
+      .sort(function(a, b) {
+        return a.id_modulo - b.id_modulo;
+      });
+
+    renderizarSidebar();
+
+    if (respondidos.length > 0) {
+      await selecionarModulo(respondidos[0]);
+    } else {
+      renderizarPainelVazio();
+    }
+  } catch (e) {
+    console.error("Erro ao carregar dados:", e);
+    renderizarPainelErro();
+  }
+}
+
+function renderizarSidebar() {
+  if (respondidos.length === 0) {
+    sidebarLista.innerHTML = '<p class="sidebar-vazio">Nenhuma prova realizada ainda.</p>';
+    return;
+  }
+
+  sidebarLista.innerHTML = "";
+
+  respondidos.forEach(function(modulo) {
+    var aprovado = modulo.nota >= Math.ceil(modulo.questoes * 0.6);
+
+    var item = document.createElement("button");
+    item.type = "button";
+    item.className = "historico-modulo-item historico-modulo-item--" + (aprovado ? "aprovado" : "reprovado");
+    item.dataset.id = modulo.id_modulo;
+    item.innerHTML =
+      '<div class="historico-modulo-info">' +
+        '<span class="historico-modulo-titulo">' + escapeHtml(modulo.titulo) + "</span>" +
+        '<span class="historico-modulo-nota">' + modulo.nota + " / " + modulo.questoes + "</span>" +
+      "</div>";
+
+    item.addEventListener("click", function() {
+      selecionarModulo(modulo);
+    });
+
+    sidebarLista.appendChild(item);
+  });
+}
+
+async function selecionarModulo(modulo) {
+  moduloSelecionado = modulo;
+  atualizarSidebarAtiva();
+  renderizarPainelCarregando();
+
+  try {
+    var response = await apiFetch("/api/questoes/historico/" + modulo.id_modulo);
+    if (!response) return;
+
+    if (!response.ok) {
+      renderizarPainelErro("Não foi possível carregar as questões deste módulo.");
+      return;
+    }
+
+    var questoes = await response.json();
+    renderizarPainel(modulo, questoes);
+  } catch (e) {
+    console.error("Erro ao carregar histórico do módulo:", e);
+    renderizarPainelErro();
+  }
+}
+
+function atualizarSidebarAtiva() {
+  document.querySelectorAll(".historico-modulo-item").forEach(function(item) {
+    var ativo = Number(item.dataset.id) === (moduloSelecionado && moduloSelecionado.id_modulo);
+    item.classList.toggle("historico-modulo-item--ativo", ativo);
+  });
+}
+
+function renderizarPainel(modulo, questoes) {
+  var acertos = 0;
+  questoes.forEach(function(q) {
+    if (q.nota === 1) acertos++;
+  });
+  var total = questoes.length;
+  var aprovado = total > 0 && acertos >= Math.ceil(total * 0.6);
+
+  var questoesHtml = "";
+  questoes.forEach(function(q, i) {
+    questoesHtml += renderizarQuestao(q, i);
+  });
+
+  historicoPainel.innerHTML =
+    '<div class="painel-topo">' +
+      "<div>" +
+        '<span class="painel-badge painel-badge--' + (aprovado ? "aprovado" : "reprovado") + '">' +
+          (aprovado ? "Aprovado" : "Reprovado") +
+        "</span>" +
+        '<h2 class="painel-titulo">' + escapeHtml(modulo.titulo) + "</h2>" +
+      "</div>" +
+      '<div class="painel-resultado">' +
+        "<span>Resultado</span>" +
+        "<strong>" + acertos + " / " + total + "</strong>" +
+      "</div>" +
+    "</div>" +
+    '<div class="questoes-lista">' + questoesHtml + "</div>";
+}
+
+function renderizarQuestao(questao, index) {
+  var alternativas = ["a", "b", "c", "d"];
+  var correta = questao.alternativa_correta;
+  var escolhida = questao.resposta_usuario;
+  var acertou = questao.nota === 1;
+
+  var opcoesHtml = "";
+  alternativas.forEach(function(letra) {
+    var texto = questao["alternativa_" + letra];
+    var classeExtra = "";
+
+    if (letra === escolhida && acertou) {
+      classeExtra = "opcao--escolhida-correta";
+    } else if (letra === escolhida && !acertou) {
+      classeExtra = "opcao--escolhida-errada";
+    } else if (letra === correta && !acertou) {
+      classeExtra = "opcao--gabarito";
+    }
+
+    opcoesHtml +=
+      '<div class="opcao ' + classeExtra + '">' +
+        '<span class="opcao-letra">' + letra.toUpperCase() + "</span>" +
+        '<span class="opcao-texto">' + escapeHtml(texto) + "</span>" +
+      "</div>";
+  });
+
+  return (
+    '<div class="questao-card questao-card--' + (acertou ? "correta" : "errada") + '">' +
+      '<div class="questao-topo">' +
+        '<span class="questao-numero">' + (index + 1) + "</span>" +
+        '<span class="questao-tag questao-tag--' + (acertou ? "correta" : "errada") + '">' +
+          (acertou ? "Acerto" : "Erro") +
+        "</span>" +
+      "</div>" +
+      '<p class="questao-enunciado">' + escapeHtml(questao.enunciado) + "</p>" +
+      '<div class="questao-opcoes">' + opcoesHtml + "</div>" +
+    "</div>"
+  );
+}
+
+function renderizarPainelCarregando() {
+  historicoPainel.innerHTML =
+    '<div class="painel-mensagem"><p>Carregando questões...</p></div>';
+}
+
+function renderizarPainelVazio() {
+  historicoPainel.innerHTML =
+    '<div class="painel-mensagem">' +
+      "<p>Você ainda não realizou nenhuma prova.</p>" +
+      '<a href="modulos.html" class="btn btn-primary">Ir para os módulos</a>' +
+    "</div>";
+}
+
+function renderizarPainelErro(msg) {
+  historicoPainel.innerHTML =
+    '<div class="painel-mensagem">' +
+      "<p>" + (msg || "Não foi possível carregar o histórico. Tente novamente.") + "</p>" +
+    "</div>";
+}
+
+function escapeHtml(value) {
+  return String(value || "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}

--- a/app/public/pages/dashboard.html
+++ b/app/public/pages/dashboard.html
@@ -61,6 +61,13 @@
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M2.5 3.5a.5.5 0 0 1 0-1h11a.5.5 0 0 1 0 1zm2-2a.5.5 0 0 1 0-1h7a.5.5 0 0 1 0 1zM0 13a1.5 1.5 0 0 0 1.5 1.5h13A1.5 1.5 0 0 0 16 13V6a1.5 1.5 0 0 0-1.5-1.5h-13A1.5 1.5 0 0 0 0 6zm6.854-4.854 3 3a.5.5 0 0 1-.708.708L6.5 9.207V12.5a.5.5 0 0 1-1 0V9.207L2.854 11.854a.5.5 0 0 1-.708-.708l3-3a.5.5 0 0 1 .708 0z"/></svg>
                     Provas
                 </a>
+                <a href="historicoquestoes.html" class="sidebar-link">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                        <path d="M8 3.5a.5.5 0 0 0-1 0V9a.5.5 0 0 0 .252.434l3.5 2a.5.5 0 0 0 .496-.868L8 8.71z"/>
+                        <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16m7-8A7 7 0 1 1 1 8a7 7 0 0 1 14 0"/>
+                    </svg>
+                    Histórico
+                </a>
             </nav>
         </aside>
 
@@ -85,7 +92,10 @@
 
                     <!-- Histórico de Tentativas -->
                     <div class="lateral-card">
-                        <h3 class="lateral-titulo">Histórico de Tentativas</h3>
+                        <div class="lateral-card-topo">
+                            <a href="historicoquestoes.html" class="lateral-titulo lateral-titulo--link">Histórico de Tentativas</a>
+                            <a href="historicoquestoes.html" class="historico-ver-todas">Ver todas</a>
+                        </div>
                         <table class="historico-tabela">
                             <thead>
                                 <tr>

--- a/app/public/pages/historicoquestoes.html
+++ b/app/public/pages/historicoquestoes.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="../assets/css/pages/historicoquestoes.css">
+    <link rel="stylesheet" href="../assets/css/pages/historicoQuestoes.css">
     <title>ScrumFlow | Histórico de Questões</title>
 </head>
 
@@ -15,9 +15,13 @@
 
     <nav class="navbar">
         <div class="navbar__container">
-            <a href="index.html" class="logo">Scrum<span class="flow">Flow</span></a>
+
+            <a href="index.html" class="logo">
+                Scrum<span class="flow">Flow</span>
+            </a>
 
             <div class="nav-menu" id="nav-menu">
+
                 <ul class="nav-links">
                     <li><a href="index.html" class="nav-link">Home</a></li>
                     <li><a href="modulo-1/manifesto.html" class="nav-link">Manifesto</a></li>
@@ -27,16 +31,12 @@
                 </ul>
 
                 <div class="navbar__actions">
-                    <!-- nav-deslogado e nav-logado são alternados pelo navbar.js -->
-                    <div id="nav-deslogado">
-                        <a href="#" id="btn-entrar" class="btn btn-ghost">Entrar</a>
-                        <a href="#" id="btn-criar-conta" class="btn btn-primary">Criar conta</a>
-                    </div>
-                    <div id="nav-logado" hidden>
+                    <div id="nav-logado">
                         <span id="nav-saudacao" class="nav-saudacao"></span>
-                        <button id="btn-sair-index" class="btn btn-ghost">Sair</button>
+                        <button id="btn-sair" class="btn btn-ghost">Sair</button>
                     </div>
                 </div>
+
             </div>
 
             <button class="navbar__hamburger" id="hamburger" aria-label="Abrir menu">
@@ -44,39 +44,59 @@
                 <span></span>
                 <span></span>
             </button>
+
         </div>
     </nav>
 
     <div class="dashboard-wrapper">
 
-        <!-- SIDEBAR: apenas links que têm página de destino real -->
         <aside class="sidebar">
             <nav class="sidebar-nav">
-                <a href="modulos.html" class="sidebar-link sidebar-link--ativo">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
-                        viewBox="0 0 16 16">
-                        <path
-                            d="M8 1a2 2 0 0 1 2 2v4H6V3a2 2 0 0 1 2-2m3 6V3a3 3 0 0 0-6 0v4a2 2 0 0 0-2 2v5a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2" />
+                <a href="modulos.html" class="sidebar-link">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                        <path d="M8 1a2 2 0 0 1 2 2v4H6V3a2 2 0 0 1 2-2m3 6V3a3 3 0 0 0-6 0v4a2 2 0 0 0-2 2v5a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2"/>
                     </svg>
                     Módulos
                 </a>
                 <a href="historicoquestoes.html" class="sidebar-link sidebar-link--ativo">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
-                        viewBox="0 0 16 16">
-                        <path
-                            d="M2.5 3.5a.5.5 0 0 1 0-1h11a.5.5 0 0 1 0 1zm2-2a.5.5 0 0 1 0-1h7a.5.5 0 0 1 0 1zM0 13a1.5 1.5 0 0 0 1.5 1.5h13A1.5 1.5 0 0 0 16 13V6a1.5 1.5 0 0 0-1.5-1.5h-13A1.5 1.5 0 0 0 0 6zm6.854-4.854 3 3a.5.5 0 0 1-.708.708L6.5 9.207V12.5a.5.5 0 0 1-1 0V9.207L2.854 11.854a.5.5 0 0 1-.708-.708l3-3a.5.5 0 0 1 .708 0z" />
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                        <path d="M2.5 3.5a.5.5 0 0 1 0-1h11a.5.5 0 0 1 0 1zm2-2a.5.5 0 0 1 0-1h7a.5.5 0 0 1 0 1zM0 13a1.5 1.5 0 0 0 1.5 1.5h13A1.5 1.5 0 0 0 16 13V6a1.5 1.5 0 0 0-1.5-1.5h-13A1.5 1.5 0 0 0 0 6zm6.854-4.854 3 3a.5.5 0 0 1-.708.708L6.5 9.207V12.5a.5.5 0 0 1-1 0V9.207L2.854 11.854a.5.5 0 0 1-.708-.708l3-3a.5.5 0 0 1 .708 0z"/>
                     </svg>
-                    Histórico de Questões
+                    Histórico
                 </a>
             </nav>
         </aside>
 
+        <main class="historico-main">
+            <div class="historico-container">
 
+                <div class="historico-header">
+                    <h1 class="historico-titulo">Histórico de <span class="historico-destaque">Questões</span></h1>
+                    <p class="historico-subtitulo">Revise as provas realizadas e veja seu desempenho questão a questão.</p>
+                </div>
+
+                <div class="historico-layout">
+
+                    <aside class="historico-sidebar">
+                        <div class="historico-sidebar-topo">
+                            <h2 class="historico-sidebar-titulo">Módulos</h2>
+                        </div>
+                        <div class="historico-sidebar-lista" id="sidebar-lista"></div>
+                    </aside>
+
+                    <section class="historico-painel" id="historico-painel"></section>
+
+                </div>
+
+            </div>
         </main>
+
     </div>
 
     <script src="../assets/js/auth.js"></script>
+    <script src="../assets/js/api.js"></script>
     <script src="../assets/js/navbar.js"></script>
+    <script src="../assets/js/historicoQuestoes.js"></script>
 
 </body>
 

--- a/app/public/pages/historicoquestoes.html
+++ b/app/public/pages/historicoquestoes.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="../assets/css/pages/historicoquestoes.css">
+    <title>ScrumFlow | Histórico de Questões</title>
+</head>
+
+<body>
+
+    <div class="blob-esquerda"></div>
+    <div class="blob-direita"></div>
+
+    <nav class="navbar">
+        <div class="navbar__container">
+            <a href="index.html" class="logo">Scrum<span class="flow">Flow</span></a>
+
+            <div class="nav-menu" id="nav-menu">
+                <ul class="nav-links">
+                    <li><a href="index.html" class="nav-link">Home</a></li>
+                    <li><a href="modulo-1/manifesto.html" class="nav-link">Manifesto</a></li>
+                    <li><a href="modulo-2/scrum.html" class="nav-link">Scrum</a></li>
+                    <li id="nav-dashboard"><a href="dashboard.html" class="nav-link">Dashboard</a></li>
+                    <li><a href="modulos.html" class="nav-link">Módulos</a></li>
+                </ul>
+
+                <div class="navbar__actions">
+                    <!-- nav-deslogado e nav-logado são alternados pelo navbar.js -->
+                    <div id="nav-deslogado">
+                        <a href="#" id="btn-entrar" class="btn btn-ghost">Entrar</a>
+                        <a href="#" id="btn-criar-conta" class="btn btn-primary">Criar conta</a>
+                    </div>
+                    <div id="nav-logado" hidden>
+                        <span id="nav-saudacao" class="nav-saudacao"></span>
+                        <button id="btn-sair-index" class="btn btn-ghost">Sair</button>
+                    </div>
+                </div>
+            </div>
+
+            <button class="navbar__hamburger" id="hamburger" aria-label="Abrir menu">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+        </div>
+    </nav>
+
+    <div class="dashboard-wrapper">
+
+        <!-- SIDEBAR: apenas links que têm página de destino real -->
+        <aside class="sidebar">
+            <nav class="sidebar-nav">
+                <a href="modulos.html" class="sidebar-link sidebar-link--ativo">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+                        viewBox="0 0 16 16">
+                        <path
+                            d="M8 1a2 2 0 0 1 2 2v4H6V3a2 2 0 0 1 2-2m3 6V3a3 3 0 0 0-6 0v4a2 2 0 0 0-2 2v5a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2" />
+                    </svg>
+                    Módulos
+                </a>
+                <a href="historicoquestoes.html" class="sidebar-link sidebar-link--ativo">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+                        viewBox="0 0 16 16">
+                        <path
+                            d="M2.5 3.5a.5.5 0 0 1 0-1h11a.5.5 0 0 1 0 1zm2-2a.5.5 0 0 1 0-1h7a.5.5 0 0 1 0 1zM0 13a1.5 1.5 0 0 0 1.5 1.5h13A1.5 1.5 0 0 0 16 13V6a1.5 1.5 0 0 0-1.5-1.5h-13A1.5 1.5 0 0 0 0 6zm6.854-4.854 3 3a.5.5 0 0 1-.708.708L6.5 9.207V12.5a.5.5 0 0 1-1 0V9.207L2.854 11.854a.5.5 0 0 1-.708-.708l3-3a.5.5 0 0 1 .708 0z" />
+                    </svg>
+                    Histórico de Questões
+                </a>
+            </nav>
+        </aside>
+
+
+        </main>
+    </div>
+
+    <script src="../assets/js/auth.js"></script>
+    <script src="../assets/js/navbar.js"></script>
+
+</body>
+
+</html>

--- a/app/src/repositories/questoes.repositories.js
+++ b/app/src/repositories/questoes.repositories.js
@@ -406,6 +406,54 @@ async function findProgressoModulosByUsuario(idUsuario) {
   });
 };
 
+// retorna as questões com respostas do usuário para a última tentativa de um módulo
+async function findHistoricoQuestoesByModulo(idUsuario, idModulo) {
+  const result = await pool.query(
+    `
+    WITH exame_usuario AS (
+      SELECT id_exame
+      FROM exames
+      WHERE id_usuario = $1
+      ORDER BY id_exame DESC
+      LIMIT 1
+    ),
+    ultima_tentativa AS (
+      SELECT q.grupo
+      FROM respostas r
+      INNER JOIN exame_usuario eu ON eu.id_exame = r.id_exame
+      INNER JOIN questoes q ON q.id_questao = r.id_questao
+      WHERE q.id_modulo = $2
+      GROUP BY q.grupo
+      ORDER BY MAX(r.respondido_em) DESC
+      LIMIT 1
+    )
+    SELECT
+      q.id_questao,
+      q.numero,
+      q.enunciado,
+      q.alternativa_a,
+      q.alternativa_b,
+      q.alternativa_c,
+      q.alternativa_d,
+      q.alternativa_correta,
+      r.resposta AS resposta_usuario,
+      r.nota::INTEGER AS nota
+    FROM ultima_tentativa ut
+    INNER JOIN questoes q
+      ON q.id_modulo = $2
+     AND q.grupo IS NOT DISTINCT FROM ut.grupo
+    INNER JOIN exame_usuario eu ON TRUE
+    INNER JOIN respostas r
+      ON r.id_exame = eu.id_exame
+     AND r.id_questao = q.id_questao
+    ORDER BY q.numero ASC NULLS LAST, q.id_questao ASC
+    `,
+    [idUsuario, idModulo],
+  );
+
+  return result.rows;
+}
+
 module.exports = {
   findProximaQuestaoByUsuario,
   findQuestaoDoExameByUsuario,
@@ -418,5 +466,6 @@ module.exports = {
   findProximoModuloByUsuario,
   updateProximoModulo,
   findModulosRespondidosByUsuario,
-  findProgressoModulosByUsuario
+  findProgressoModulosByUsuario,
+  findHistoricoQuestoesByModulo,
 };

--- a/app/src/routes/questoes.routes.js
+++ b/app/src/routes/questoes.routes.js
@@ -12,7 +12,8 @@ const {
   findProximoModuloByUsuario,
   updateProximoModulo,
   findModulosRespondidosByUsuario,
-  findProgressoModulosByUsuario
+  findProgressoModulosByUsuario,
+  findHistoricoQuestoesByModulo,
 } = require("../repositories/questoes.repositories")
 //cria objeto
 /**
@@ -233,6 +234,34 @@ router.get("/modulos", authMiddleware, async function (req, res) {
     return res.status(200).json(modulos);
   } catch (e) {
     console.error("Erro ao buscar progresso dos módulos:", e);
+    return res.status(500).json({
+      message: "erro interno do servidor",
+    });
+  }
+});
+
+/**
+ * ROTA: GET /historico/:idModulo
+ * DESCRIÇÃO: Retorna as questões e respostas do usuário para a última tentativa de um módulo específico.
+ * ACESSO: Privado (Requer Token JWT).
+ */
+router.get("/historico/:idModulo", authMiddleware, async function (req, res) {
+  try {
+    const idModulo = Number(req.params.idModulo);
+
+    if (!idModulo || idModulo < 1) {
+      return res.status(400).json({ message: "id de módulo inválido" });
+    }
+
+    const questoes = await findHistoricoQuestoesByModulo(req.usuario.id_usuario, idModulo);
+
+    if (!questoes.length) {
+      return res.status(404).json({ message: "nenhuma resposta encontrada para este módulo" });
+    }
+
+    return res.status(200).json(questoes);
+  } catch (e) {
+    console.error("Erro ao buscar histórico do módulo:", e);
     return res.status(500).json({
       message: "erro interno do servidor",
     });

--- a/docs/modelos/alteracoes-backend.md
+++ b/docs/modelos/alteracoes-backend.md
@@ -1,0 +1,151 @@
+# Alterações de Backend — Histórico de Questões (RF10)
+
+← [Índice de Modelos](./README.md)
+
+Este documento registra os novos artefatos de backend criados para implementar a página **Histórico de Questões** (`historicoquestoes.html`). O objetivo é que qualquer membro do time consiga atualizar os diagramas UML e o modelo de BD sem precisar rastrear os commits.
+
+---
+
+## Contexto
+
+O RF10 (Histórico) já existia na documentação de forma parcial — o endpoint `GET /api/questoes/modulos-respondidos` retorna estatísticas por tentativa (nota, data, questões respondidas), mas **não retornava o detalhe das questões com as respostas do usuário**. A nova página precisa exibir, questão a questão, o que o usuário respondeu, se acertou ou errou, e qual era a alternativa correta.
+
+---
+
+## O que foi adicionado
+
+### 1. Função de repositório — `findHistoricoQuestoesByModulo`
+
+**Arquivo:** `app/src/repositories/questoes.repositories.js`
+
+Retorna todas as questões respondidas da **última tentativa** do usuário em um módulo específico, incluindo a resposta do usuário e o gabarito.
+
+**Parâmetros:**
+| Parâmetro   | Tipo    | Descrição                        |
+|-------------|---------|----------------------------------|
+| `idUsuario` | integer | ID do usuário autenticado (JWT)  |
+| `idModulo`  | integer | ID do módulo a consultar         |
+
+**Retorno (array de objetos):**
+| Campo              | Tipo    | Descrição                                      |
+|--------------------|---------|------------------------------------------------|
+| `id_questao`       | integer | Identificador da questão                       |
+| `numero`           | integer | Número de ordem da questão na prova            |
+| `enunciado`        | string  | Texto da pergunta                              |
+| `alternativa_a`    | string  | Texto da alternativa A                         |
+| `alternativa_b`    | string  | Texto da alternativa B                         |
+| `alternativa_c`    | string  | Texto da alternativa C                         |
+| `alternativa_d`    | string  | Texto da alternativa D                         |
+| `alternativa_correta` | string | Letra da alternativa correta (`"a"`, `"b"`, `"c"` ou `"d"`) |
+| `resposta_usuario` | string  | Letra que o usuário escolheu                   |
+| `nota`             | integer | `1` se acertou, `0` se errou                   |
+
+**Lógica da query:**
+
+1. Busca o `id_exame` mais recente do usuário (há um exame por usuário, atualizado em place).
+2. Dentro desse exame, identifica o `grupo` de questões da **última tentativa** no módulo especificado (pelo `MAX(respondido_em)` agrupado por grupo).
+3. Retorna todas as questões desse grupo com as respectivas respostas registradas na tabela `respostas`.
+
+> **Por que "última tentativa"?** Um usuário pode ter tentado o mesmo módulo até 2 vezes (grupos diferentes). O histórico exibe sempre a tentativa mais recente.
+
+---
+
+### 2. Nova rota — `GET /api/questoes/historico/:idModulo`
+
+**Arquivo:** `app/src/routes/questoes.routes.js`
+
+**Acesso:** Privado — requer `Authorization: Bearer <token>` (middleware `authMiddleware`).
+
+**Parâmetro de rota:**
+| Parâmetro  | Tipo    | Descrição                |
+|------------|---------|--------------------------|
+| `idModulo` | integer | ID do módulo a consultar |
+
+**Respostas HTTP:**
+
+| Status | Situação                                                   |
+|--------|------------------------------------------------------------|
+| `200`  | Questões encontradas — retorna o array descrito acima      |
+| `400`  | `idModulo` não é um número inteiro positivo válido         |
+| `404`  | Usuário não tem nenhuma resposta registrada nesse módulo   |
+| `500`  | Erro interno do servidor                                   |
+
+**Exemplo de resposta `200`:**
+```json
+[
+  {
+    "id_questao": 5,
+    "numero": 1,
+    "enunciado": "Qual dos itens abaixo NÃO é um valor do Manifesto Ágil?",
+    "alternativa_a": "Indivíduos e interações",
+    "alternativa_b": "Software funcionando",
+    "alternativa_c": "Processos e ferramentas",
+    "alternativa_d": "Colaboração com o cliente",
+    "alternativa_correta": "c",
+    "resposta_usuario": "b",
+    "nota": 0
+  },
+  {
+    "id_questao": 7,
+    "numero": 2,
+    "enunciado": "Em que ano foi publicado o Manifesto Ágil?",
+    "alternativa_a": "1999",
+    "alternativa_b": "2001",
+    "alternativa_c": "2003",
+    "alternativa_d": "2005",
+    "alternativa_correta": "b",
+    "resposta_usuario": "b",
+    "nota": 1
+  }
+]
+```
+
+---
+
+## Rotas existentes utilizadas pela mesma página
+
+A página `historicoquestoes.html` também consome o endpoint já existente abaixo, sem modificações:
+
+| Método | Endpoint                              | Uso na página                                    |
+|--------|---------------------------------------|--------------------------------------------------|
+| `GET`  | `/api/questoes/modulos-respondidos`   | Popula a lista lateral de módulos já tentados    |
+
+---
+
+## Impacto nos diagramas — o que precisa ser atualizado
+
+### RF10 — Histórico (`RF10_dc_historico.svg` e `RF10_ds_historico.svg`)
+
+Os diagramas atuais de RF10 mostram o fluxo de `exibir_historico()` de forma genérica. Com essa entrega, o fluxo ganhou um detalhe novo que deve ser refletido:
+
+**Diagrama de Sequência (`RF10_ds_historico.svg`) — sugestão de atualização:**
+- Adicionar a mensagem do Frontend para o Backend: `GET /historico/:idModulo`
+- Adicionar a consulta do Backend ao BD: query nas tabelas `exames`, `respostas` e `questoes` (join triplo com CTE `ultima_tentativa`)
+- Adicionar o retorno: array com `enunciado`, `alternativa_correta`, `resposta_usuario`, `nota`
+
+**Diagrama de Classes (`RF10_dc_historico.svg`) — sugestão de atualização:**
+- O método `exibir_historico()` pode ser desdobrado em dois: `listarModulosRespondidos()` (já existia) e `buscarQuestoesPorModulo(idModulo)` (novo)
+
+### Modelo Lógico de BD
+
+Nenhuma tabela nova foi criada. A query utiliza apenas as tabelas já existentes:
+- `exames` (para identificar o exame do usuário)
+- `respostas` (para recuperar as respostas registradas)
+- `questoes` (para recuperar enunciado, alternativas e gabarito)
+
+O modelo lógico **não precisa ser alterado**.
+
+---
+
+## Arquivos alterados neste PR
+
+```
+app/src/repositories/questoes.repositories.js  ← função findHistoricoQuestoesByModulo adicionada
+app/src/routes/questoes.routes.js              ← rota GET /historico/:idModulo adicionada
+```
+
+---
+
+<div align="center">
+  <a href="./README.md">← Voltar ao Índice de Modelos</a>
+</div>


### PR DESCRIPTION
Cria a página de revisão de provas onde o usuário pode ver, módulo a módulo, as questões que respondeu com indicação de acerto ou erro e qual era a resposta correta.

O que foi feito:

Nova rota GET /api/questoes/historico/:idModulo que retorna as questões e respostas da última tentativa do usuário em um módulo
Página historicoquestoes.html com sidebar de módulos tentados e painel de questões
Dashboard atualizado: link "Histórico" na sidebar, título "Histórico de Tentativas" clicável e botão "Ver todas" apontando para a nova página
Corrigido bug no dashboard que mostrava todas as tentativas no histórico — agora exibe apenas a melhor nota por módulo
Documentação em docs/modelos/alteracoes-backend.md explicando o novo endpoint e o que precisa ser atualizado nos diagramas UML