### PR TITLE
fix executa script de schema admin no db:init

### DIFF
--- a/app/src/infra/run-sql.js
+++ b/app/src/infra/run-sql.js
@@ -24,8 +24,8 @@ const sqlFiles = [
   "05_schema_respostas.sql", // Estrutura de Respostas do usuário
   "06_seed_modulos.sql",     // Dados iniciais de Módulos
   "07_seed_questoes.sql",    // Dados iniciais de Questões
+  "08_seed_schema_admin.sql", // Estrutura e seed de administrador
 ];
-
 /**
  * Lê e executa todos os arquivos SQL definidos no array sqlFiles.
  * Realiza o encerramento do pool de conexões após a conclusão.


### PR DESCRIPTION
## Correção do processo de inicialização do banco de dados

### Problema

O script `08_seed_schema_admin.sql` existia no projeto, porém não estava sendo executado pelo comando `npm run db:init`.

Como consequência, estruturas relacionadas à funcionalidade de administrador, incluindo a coluna `is_admin`, não eram criadas no banco local, causando falhas de autenticação e erros de execução.

### Alterações realizadas

* Adicionado o arquivo `08_seed_schema_admin.sql` à lista de scripts executados pelo `run-sql.js`.
* Garantida a execução completa de todos os scripts de inicialização do banco.

### Resultado esperado

Após executar:

```bash
npm run db:init
```

todos os scripts SQL serão aplicados corretamente, incluindo as configurações necessárias para a área administrativa do sistema.
