### PR TITLE
feat(s3): melhorias de layout, controle de tentativas e painel admin …

### DIFF
--- a/app/public/assets/css/pages/configuracoes.css
+++ b/app/public/assets/css/pages/configuracoes.css
@@ -103,6 +103,13 @@
     color: var(--teal-500);
 }
 
+/* Variação amber para a seção de progresso */
+.config-card-icon--amber {
+    background-color: rgba(245, 158, 11, 0.1);
+    border-color: rgba(245, 158, 11, 0.25);
+    color: var(--amber-500);
+}
+
 .config-card-titulo {
     font-family: var(--font-heading);
     font-size: 16px;
@@ -429,4 +436,80 @@
         width: 100%;
         text-align: center;
     }
+}
+
+/* ================================
+   MODAL: PROGRESSO DOS ALUNOS
+================================ */
+
+.admin-modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(10, 22, 40, 0.75);
+    backdrop-filter: blur(4px);
+    z-index: 1200;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+}
+
+.admin-modal {
+    background: var(--navy-800);
+    border: 1px solid rgba(245, 158, 11, 0.2);
+    border-radius: 16px;
+    width: 100%;
+    max-width: 820px;
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 16px 48px rgba(10, 22, 40, 0.8);
+}
+
+.admin-modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 20px 24px;
+    border-bottom: 1px solid rgba(163, 184, 216, 0.1);
+    flex-shrink: 0;
+}
+
+.admin-modal-titulo {
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--white);
+    margin: 0;
+}
+
+.admin-modal-fechar {
+    background: none;
+    border: none;
+    color: var(--navy-300);
+    font-size: 18px;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 6px;
+    transition: color 0.2s, background 0.2s;
+}
+
+.admin-modal-fechar:hover {
+    color: var(--white);
+    background: rgba(163, 184, 216, 0.1);
+}
+
+.admin-modal-body {
+    padding: 20px 24px;
+    overflow-y: auto;
+    flex: 1;
+}
+
+.admin-modal-aviso {
+    font-size: 12px;
+    color: var(--navy-300);
+    margin: 0 0 16px;
+    padding: 10px 14px;
+    background: rgba(245, 158, 11, 0.06);
+    border: 1px solid rgba(245, 158, 11, 0.15);
+    border-radius: 8px;
 }

--- a/app/public/assets/css/pages/modulos.css
+++ b/app/public/assets/css/pages/modulos.css
@@ -387,6 +387,17 @@
     gap: 16px;
 }
 
+.tentativas-esgotadas-msg {
+    font-size: 13px;
+    color: var(--navy-300);
+    line-height: 1.6;
+    margin: 0;
+    padding: 12px 16px;
+    background: rgba(163, 184, 216, 0.06);
+    border: 1px solid rgba(163, 184, 216, 0.12);
+    border-radius: 8px;
+}
+
 /* ================================
    RESPONSIVO
 ================================ */

--- a/app/public/assets/css/pages/questoes.css
+++ b/app/public/assets/css/pages/questoes.css
@@ -22,6 +22,20 @@
   width: 100%;
 }
 
+.questao-imagem[hidden] {
+  display: none;
+}
+
+.questao-ref {
+  display: block;
+  font-size: 11px;
+  color: var(--navy-400);
+  text-align: right;
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(163, 184, 216, 0.08);
+}
+
 /* CABEÇALHO DA AVALIAÇÃO */
 .questoes-header {
   background: linear-gradient(135deg, var(--navy-900) 0%, var(--navy-800) 100%);

--- a/app/public/assets/js/configuracoes.js
+++ b/app/public/assets/js/configuracoes.js
@@ -24,7 +24,7 @@
         if (!token) return false;
         try {
             const payload = JSON.parse(atob(token.split('.')[1]));
-            return payload.perfil === 'admin';
+            return payload.is_admin === true;
         } catch {
             return false;
         }
@@ -50,6 +50,7 @@
         secaoAdmin.hidden = false;
         carregarQuestoes();
         carregarNiveis();
+        configurarModalProgresso();
     }
 
     // ── Formulário: dados pessoais ────────────────────────────────────
@@ -221,6 +222,103 @@
             `;
         }).join('');
     }
+
+    // ── Modal: Gerenciar Progresso ────────────────────────────────────
+    function configurarModalProgresso() {
+        const btnAbrir  = document.getElementById('btn-gerenciar-progresso');
+        const modal     = document.getElementById('modal-progresso');
+        const btnFechar = document.getElementById('btn-fechar-modal-progresso');
+
+        if (!btnAbrir || !modal) return;
+
+        btnAbrir.addEventListener('click', function () {
+            modal.hidden = false;
+            carregarProgressoUsuarios();
+        });
+
+        btnFechar.addEventListener('click', function () {
+            modal.hidden = true;
+        });
+
+        modal.addEventListener('click', function (e) {
+            if (e.target === modal) modal.hidden = true;
+        });
+    }
+
+    function carregarProgressoUsuarios() {
+        const tbody = document.getElementById('usuarios-progresso-tbody');
+        if (!tbody) return;
+        tbody.innerHTML = '<tr><td colspan="5" style="text-align:center;padding:20px;color:var(--navy-400)">Carregando...</td></tr>';
+
+        const token = obterToken();
+        fetch('/api/admin/usuarios-progresso', {
+            headers: { 'Authorization': 'Bearer ' + token }
+        })
+        .then(function (r) { return r.json(); })
+        .then(function (usuarios) {
+            if (!usuarios.length) {
+                tbody.innerHTML = '<tr><td colspan="5" style="text-align:center;padding:20px;color:var(--navy-400)">Nenhum aluno cadastrado.</td></tr>';
+                return;
+            }
+            tbody.innerHTML = usuarios.map(function (u) {
+                const modulo     = u.modulo_titulo ? 'Módulo ' + u.id_modulo + ' – ' + u.modulo_titulo : '—';
+                const tentativas = u.id_exame
+                    ? u.tentativas_modulo_atual + ' / 2'
+                    : '—';
+                return '<tr>' +
+                    '<td>' + escapeHtml(u.nome) + '</td>' +
+                    '<td style="font-size:12px;color:var(--navy-300)">' + escapeHtml(u.email) + '</td>' +
+                    '<td>' + modulo + '</td>' +
+                    '<td>' + tentativas + '</td>' +
+                    '<td>' +
+                        '<div class="config-tabela-acoes">' +
+                            (u.id_exame
+                                ? '<button class="btn-tabela btn-tabela--editar" onclick="zerarModulo(' + u.id_usuario + ', \'' + escapeHtml(u.nome) + '\')">Zerar módulo</button>' +
+                                  '<button class="btn-tabela btn-tabela--excluir" onclick="reiniciarUsuario(' + u.id_usuario + ', \'' + escapeHtml(u.nome) + '\')">Módulo 1</button>'
+                                : '<span style="font-size:12px;color:var(--navy-400)">Sem exame</span>') +
+                        '</div>' +
+                    '</td>' +
+                '</tr>';
+            }).join('');
+        })
+        .catch(function () {
+            tbody.innerHTML = '<tr><td colspan="5" style="text-align:center;padding:20px;color:var(--red-400)">Erro ao carregar.</td></tr>';
+        });
+    }
+
+    function escapeHtml(str) {
+        return String(str || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+    }
+
+    window.zerarModulo = function (idUsuario, nome) {
+        if (!confirm('Zerar tentativas do módulo atual de "' + nome + '"?\n\nIsso apaga as respostas do módulo atual e permite que o aluno recomece a partir da tentativa 1.')) return;
+        const token = obterToken();
+        fetch('/api/admin/usuarios/' + idUsuario + '/zerar-modulo', {
+            method: 'PATCH',
+            headers: { 'Authorization': 'Bearer ' + token }
+        })
+        .then(function (r) { return r.json().then(function (d) { return { ok: r.ok, data: d }; }); })
+        .then(function (res) {
+            mostrarToast(res.ok ? res.data.message : (res.data.message || 'Erro ao zerar módulo.'), res.ok ? 'sucesso' : 'erro');
+            if (res.ok) carregarProgressoUsuarios();
+        })
+        .catch(function () { mostrarToast('Erro de conexão.', 'erro'); });
+    };
+
+    window.reiniciarUsuario = function (idUsuario, nome) {
+        if (!confirm('Reiniciar "' + nome + '" para o Módulo 1?\n\nIsso apaga TODAS as respostas e o histórico de provas do aluno. Esta ação não pode ser desfeita.')) return;
+        const token = obterToken();
+        fetch('/api/admin/usuarios/' + idUsuario + '/reiniciar', {
+            method: 'PATCH',
+            headers: { 'Authorization': 'Bearer ' + token }
+        })
+        .then(function (r) { return r.json().then(function (d) { return { ok: r.ok, data: d }; }); })
+        .then(function (res) {
+            mostrarToast(res.ok ? res.data.message : (res.data.message || 'Erro ao reiniciar.'), res.ok ? 'sucesso' : 'erro');
+            if (res.ok) carregarProgressoUsuarios();
+        })
+        .catch(function () { mostrarToast('Erro de conexão.', 'erro'); });
+    };
 
     // ── Ações das tabelas (expostas no escopo global pelo onclick) ────
     window.editarQuestao  = function () { mostrarToast('Edição de questão: em desenvolvimento (T16)', 'erro'); };

--- a/app/public/assets/js/modulos.js
+++ b/app/public/assets/js/modulos.js
@@ -498,7 +498,8 @@ function atualizarTela(modulo) {
   painelBadge.textContent = formatarStatus(modulo.status);
   painelTitulo.textContent = modulo.nome;
   painelDescricao.textContent = gerarDescricao(modulo);
-  painelTentativas.textContent = `${modulo.tentativasUsadas} / ${modulo.tentativasMaximas}`;
+  const tentativasExibidas = Math.min(modulo.tentativasUsadas, modulo.tentativasMaximas);
+  painelTentativas.textContent = `${tentativasExibidas} / ${modulo.tentativasMaximas}`;
 
   renderizarConteudo(modulo);
   atualizarSidebarAtiva();
@@ -529,6 +530,16 @@ function atualizarBotoes(modulo) {
   if (modulo.status === "bloqueado") {
     botoesAcao.innerHTML = `
       <button class="btn btn-ghost" disabled>Conclua o módulo anterior</button>
+    `;
+    return;
+  }
+
+  if (modulo.status !== "concluido" && modulo.tentativasUsadas >= modulo.tentativasMaximas) {
+    botoesAcao.innerHTML = `
+      <p class="tentativas-esgotadas-msg">
+        Você atingiu o limite de tentativas para este módulo.
+        Entre em contato com o administrador do curso para continuar.
+      </p>
     `;
     return;
   }

--- a/app/public/assets/js/questoes.js
+++ b/app/public/assets/js/questoes.js
@@ -133,13 +133,16 @@ function renderizarQuestao() {
 
   document.getElementById("nivel-info").textContent = obterNivelInfo(idModulo);
   document.getElementById("tentativa-info").textContent =
-    `Tentativa ${tentativaAtual}/2`;
+    tentativaAtual <= 2 ? `Tentativa ${tentativaAtual}/2` : "Revisão de conteúdo";
   document.getElementById("questao-numero").textContent =
     `Questão ${questao.numero || indiceAtual + 1}`;
   document.getElementById("questao-titulo").textContent =
     questao.enunciado || "";
-  document.getElementById("questao-imagem").src =
-    questao.imagem ? `/imagens/questoes/${questao.imagem}` : "";
+  const imgEl = document.getElementById("questao-imagem");
+  imgEl.src = questao.imagem ? `/imagens/questoes/${questao.imagem}` : "";
+  imgEl.hidden = !questao.imagem;
+  document.getElementById("questao-ref").textContent =
+    questao.id_questao ? `REF.: ${questao.id_questao}` : "";
   document.getElementById("questao-descricao").textContent = modoLeitura
     ? "Questão já respondida — somente leitura."
     : "Escolha a alternativa correta:";

--- a/app/public/assets/js/resultado.js
+++ b/app/public/assets/js/resultado.js
@@ -146,21 +146,17 @@ function atualizarMensagemResultado(dados, status) {
 async function avancarProgresso(status) {
   try {
     if (status === 'aprovado') {
-      // Usuário atingiu 60% ou mais: avança para o próximo módulo da trilha
       await fetch('/api/questoes/proximo-modulo', {
         method: 'PATCH',
         headers: { 'Authorization': `Bearer ${obterToken()}` }
       });
     } else {
-      // Usuário ficou abaixo de 60%: prepara nova tentativa com grupo diferente de questões.
-      // O servidor rejeita automaticamente se o limite de 2 tentativas já foi atingido.
       await fetch('/api/questoes/proxima-tentativa', {
         method: 'PATCH',
         headers: { 'Authorization': `Bearer ${obterToken()}` }
       });
     }
   } catch (erro) {
-    // Erro silencioso: não interrompe a exibição do resultado para o usuário
     console.error('Erro ao avançar progresso:', erro);
   }
 }

--- a/app/public/pages/configuracoes.html
+++ b/app/public/pages/configuracoes.html
@@ -167,6 +167,22 @@
                     </span>
                 </div>
 
+                <!-- Card: Progresso dos Alunos -->
+                <div class="config-card config-card--full">
+                    <div class="config-card-header">
+                        <div class="config-card-icon config-card-icon--amber">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16">
+                                <path d="M7 14s-1 0-1-1 1-4 5-4 5 3 5 4-1 1-1 1zm4-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6m-5.784 6A2.24 2.24 0 0 1 5 13c0-1.355.68-2.75 1.936-3.72A6.3 6.3 0 0 0 5 9c-4 0-5 3-5 4s1 1 1 1zM4.5 8a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5"/>
+                            </svg>
+                        </div>
+                        <div>
+                            <h3 class="config-card-titulo">Progresso dos Alunos</h3>
+                            <p class="config-card-subtitulo">Gerencie tentativas e reposicione usuários nos módulos</p>
+                        </div>
+                        <button class="btn btn-primary config-btn-nova" id="btn-gerenciar-progresso">Gerenciar</button>
+                    </div>
+                </div>
+
                 <!-- Card: Gerenciar Questões -->
                 <div class="config-card config-card--full">
                     <div class="config-card-header">
@@ -303,6 +319,35 @@
             </div>
         </div>
     </footer>
+
+    <!-- Modal: Progresso dos Alunos -->
+    <div class="admin-modal-overlay" id="modal-progresso" hidden>
+        <div class="admin-modal">
+            <div class="admin-modal-header">
+                <h3 class="admin-modal-titulo">Progresso dos Alunos</h3>
+                <button class="admin-modal-fechar" id="btn-fechar-modal-progresso" aria-label="Fechar">✕</button>
+            </div>
+            <div class="admin-modal-body">
+                <p class="admin-modal-aviso">Ações destrutivas apagam respostas permanentemente. Confirme antes de prosseguir.</p>
+                <div class="config-tabela-wrapper">
+                    <table class="config-tabela">
+                        <thead>
+                            <tr>
+                                <th>Nome</th>
+                                <th>E-mail</th>
+                                <th>Módulo atual</th>
+                                <th>Tentativas</th>
+                                <th>Ações</th>
+                            </tr>
+                        </thead>
+                        <tbody id="usuarios-progresso-tbody">
+                            <tr><td colspan="5" style="text-align:center;padding:20px;color:var(--navy-400)">Carregando...</td></tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
 
     <!-- Toast de feedback (sucesso / erro) -->
     <div class="config-toast" id="config-toast" hidden>

--- a/app/public/pages/exame/questoes.html
+++ b/app/public/pages/exame/questoes.html
@@ -73,6 +73,7 @@
           </div>
 
           <div class="questao-opcoes"></div>
+          <span id="questao-ref" class="questao-ref"></span>
         </div>
 
         <div class="progresso-container">

--- a/app/public/pages/sobre.html
+++ b/app/public/pages/sobre.html
@@ -50,31 +50,16 @@
                 <div class="sobre-hero__copy">
                     <span class="sobre-eyebrow">Projeto ABP 1DSM 2026/1</span>
                     <h1>ScrumFlow transforma o estudo de Scrum em uma jornada de certificação prática.</h1>
-                    <p>Uma plataforma criada para estudantes da FATEC Jacareí que une conteúdo, exercícios e avaliação em um fluxo intuitivo, visual e focado em resultados.</p>
-                    <div class="sobre-hero__actions">
-                        <a href="modulos.html" class="btn btn-primary">Ver módulos</a>
-                        <a href="dashboard.html" class="btn btn-ghost">Ir ao painel</a>
-                    </div>
-                    <div class="sobre-stats">
-                        <div class="sobre-stat">
-                            <strong>5</strong>
-                            <span>Módulos</span>
-                        </div>
-                        <div class="sobre-stat">
-                            <strong>+150</strong>
-                            <span>Questões</span>
-                        </div>
-                        <div class="sobre-stat">
-                            <strong>100%</strong>
-                            <span>Online</span>
-                        </div>
-                    </div>
+                    <p>Uma plataforma criada para estudantes da FATEC Jacareí que une conteúdo, exercícios e avaliação
+                        em um fluxo intuitivo, visual e focado em resultados.</p>
+
                 </div>
                 <aside class="sobre-hero__panel">
                     <span class="panel-label">Instituição</span>
                     <img src="../assets/img/logo_fatec_transparente.png" alt="Logo FATEC Jacareí">
                     <strong>FATEC Jacareí</strong>
-                    <span>Desenvolvido para o curso de Análise e Desenvolvimento de Sistemas, sob a disciplina de ABP.</span>
+                    <span>Desenvolvido para o curso de Análise e Desenvolvimento de Sistemas, sob a disciplina de
+                        ABP.</span>
                     <div class="sobre-panel__list">
                         <div>
                             <span>Meta</span>
@@ -92,23 +77,27 @@
         <section class="sobre-section sobre-section--overview">
             <div class="sobre-section__header">
                 <h2>O que o ScrumFlow entrega</h2>
-                <p>Uma experiência de estudo estruturada que mistura teoria, prática e certificação em uma única aplicação.</p>
+                <p>Uma experiência de estudo estruturada que mistura teoria, prática e certificação em uma única
+                    aplicação.</p>
             </div>
             <div class="sobre-grid sobre-grid--project">
                 <article class="sobre-card sobre-card--wide">
                     <span class="sobre-card__label">Visão</span>
                     <h2>Ser referência acadêmica em certificação ágil.</h2>
-                    <p>O ScrumFlow foi pensado para apoiar o desenvolvimento das habilidades de gestão ágil e entregar um produto reconhecido dentro do ambiente acadêmico.</p>
+                    <p>O ScrumFlow foi pensado para apoiar o desenvolvimento das habilidades de gestão ágil e entregar
+                        um produto reconhecido dentro do ambiente acadêmico.</p>
                 </article>
                 <article class="sobre-card">
                     <span class="sobre-card__label">Missão</span>
                     <h2>Organizar aprendizado com clareza.</h2>
-                    <p>Transformar conceitos de Scrum em conteúdo simples, com prática contínua e indicadores visuais que ajudam a fixar o conhecimento.</p>
+                    <p>Transformar conceitos de Scrum em conteúdo simples, com prática contínua e indicadores visuais
+                        que ajudam a fixar o conhecimento.</p>
                 </article>
                 <article class="sobre-card">
                     <span class="sobre-card__label">Diferencial</span>
                     <h2>Experiência pensada para estudantes.</h2>
-                    <p>A navegação fluida, o layout acessível e as métricas de progresso tornam o portal agradável e eficaz.</p>
+                    <p>A navegação fluida, o layout acessível e as métricas de progresso tornam o portal agradável e
+                        eficaz.</p>
                 </article>
             </div>
         </section>
@@ -125,7 +114,8 @@
                         <span class="team-card__badge">Product Owner</span>
                     </div>
                     <h3>Gustavo Koiti</h3>
-                    <p>Responsável por priorizar as entregas, definir o backlog e manter o produto alinhado aos objetivos do curso.</p>
+                    <p>Responsável por priorizar as entregas, definir o backlog e manter o produto alinhado aos
+                        objetivos do curso.</p>
                     <div class="team-card__links">
                         <a href="https://github.com/gustavokoitiyoshimura" target="_blank" rel="noopener">GitHub</a>
                         <a href="https://linkedin.com/in/" target="_blank" rel="noopener">LinkedIn</a>
@@ -140,7 +130,8 @@
                     <p>Garantiu a cadência, a comunicação e as retrospectivas para que o time seguisse o fluxo ágil.</p>
                     <div class="team-card__links">
                         <a href="https://github.com/travensolli" target="_blank" rel="noopener">GitHub</a>
-                        <a href="https://www.linkedin.com/in/gabrieltravensolli/" target="_blank" rel="noopener">LinkedIn</a>
+                        <a href="https://www.linkedin.com/in/gabrieltravensolli/" target="_blank"
+                            rel="noopener">LinkedIn</a>
                     </div>
                 </article>
                 <article class="team-card">
@@ -152,7 +143,8 @@
                     <p>Contribuiu no desenvolvimento da interface e na construção das páginas do portal.</p>
                     <div class="team-card__links">
                         <a href="https://github.com/DeaTuribio" target="_blank" rel="noopener">GitHub</a>
-                        <a href="https://www.linkedin.com/in/andrea-turibio-41507467/" target="_blank" rel="noopener">LinkedIn</a>
+                        <a href="https://www.linkedin.com/in/andrea-turibio-41507467/" target="_blank"
+                            rel="noopener">LinkedIn</a>
                     </div>
                 </article>
                 <article class="team-card">
@@ -164,7 +156,8 @@
                     <p>Implementou funcionalidades e ajudou a integrar o portal com a experiência de usuário.</p>
                     <div class="team-card__links">
                         <a href="https://github.com/henriqueptbd-cell" target="_blank" rel="noopener">GitHub</a>
-                        <a href="https://www.linkedin.com/in/henrique-camargo-6275a6394/" target="_blank" rel="noopener">LinkedIn</a>
+                        <a href="https://www.linkedin.com/in/henrique-camargo-6275a6394/" target="_blank"
+                            rel="noopener">LinkedIn</a>
                     </div>
                 </article>
                 <article class="team-card">
@@ -176,7 +169,8 @@
                     <p>Focou na arquitetura do front-end e na organização das páginas de conteúdo.</p>
                     <div class="team-card__links">
                         <a href="https://github.com/LUCASAMR23" target="_blank" rel="noopener">GitHub</a>
-                        <a href="https://www.linkedin.com/in/lucas-amorim-4b3312362/" target="_blank" rel="noopener">LinkedIn</a>
+                        <a href="https://www.linkedin.com/in/lucas-amorim-4b3312362/" target="_blank"
+                            rel="noopener">LinkedIn</a>
                     </div>
                 </article>
                 <article class="team-card">
@@ -188,7 +182,8 @@
                     <p>Trabalhou no layout e nas interações do portal, garantindo fluidez visual em cada tela.</p>
                     <div class="team-card__links">
                         <a href="https://github.com/mparise28-dev" target="_blank" rel="noopener">GitHub</a>
-                        <a href="https://www.linkedin.com/in/marcello-parise-campbell-fonseca-147965194/" target="_blank" rel="noopener">LinkedIn</a>
+                        <a href="https://www.linkedin.com/in/marcello-parise-campbell-fonseca-147965194/"
+                            target="_blank" rel="noopener">LinkedIn</a>
                     </div>
                 </article>
                 <article class="team-card">
@@ -197,10 +192,12 @@
                         <span class="team-card__badge">Desenvolvedor</span>
                     </div>
                     <h3>Vinicius Augusto</h3>
-                    <p>Auxiliou nas funcionalidades, no layout e no suporte técnico para manter a consistência do portal.</p>
+                    <p>Auxiliou nas funcionalidades, no layout e no suporte técnico para manter a consistência do
+                        portal.</p>
                     <div class="team-card__links">
                         <a href="https://github.com/viniciusaugusto1997" target="_blank" rel="noopener">GitHub</a>
-                        <a href="https://linkedin.com/in/" target="_blank" rel="noopener" aria-disabled="true">LinkedIn</a>
+                        <a href="https://linkedin.com/in/" target="_blank" rel="noopener"
+                            aria-disabled="true">LinkedIn</a>
                     </div>
                 </article>
             </div>
@@ -215,7 +212,8 @@
                 <article class="sobre-card">
                     <span class="sobre-card__label">Valor</span>
                     <h2>Aprendizado acessível</h2>
-                    <p>Conteúdos apresentados de forma simples e direta, para que todos possam acompanhar sem perder o foco.</p>
+                    <p>Conteúdos apresentados de forma simples e direta, para que todos possam acompanhar sem perder o
+                        foco.</p>
                 </article>
                 <article class="sobre-card">
                     <span class="sobre-card__label">Valor</span>
@@ -225,7 +223,8 @@
                 <article class="sobre-card sobre-card--wide">
                     <span class="sobre-card__label">Promessa</span>
                     <h2>Mais do que um site, uma experiência de estudo.</h2>
-                    <p>O objetivo é criar um ambiente que prepare o aluno para aplicar Scrum com confiança e competência.</p>
+                    <p>O objetivo é criar um ambiente que prepare o aluno para aplicar Scrum com confiança e
+                        competência.</p>
                 </article>
             </div>
         </section>
@@ -235,7 +234,8 @@
         <div class="container">
             <hr class="footer__divider">
             <div class="footer__bottom">
-                <p class="footer__copy">&copy; 2026 <strong>ScrumFlow</strong> &mdash; DEVassos. Todos os direitos reservados.</p>
+                <p class="footer__copy">&copy; 2026 <strong>ScrumFlow</strong> &mdash; DEVassos. Todos os direitos
+                    reservados.</p>
             </div>
         </div>
     </footer>

--- a/app/src/routes/admin.routes.js
+++ b/app/src/routes/admin.routes.js
@@ -76,6 +76,106 @@ router.get("/usuarios", async (req, res) => {
 });
 
 // ================================
+//   PROGRESSO DE USUÁRIOS
+// ================================
+
+router.get("/usuarios-progresso", async (req, res) => {
+  try {
+    const pool = require("../database/db");
+    const result = await pool.query(`
+      SELECT
+        u.id_usuario,
+        u.nome,
+        u.email,
+        e.id_exame,
+        e.id_modulo,
+        m.titulo AS modulo_titulo,
+        e.tentativa AS tentativa_atual,
+        COALESCE((
+          SELECT COUNT(DISTINCT q2.grupo)::INTEGER
+          FROM respostas r2
+          INNER JOIN questoes q2 ON q2.id_questao = r2.id_questao
+          WHERE r2.id_exame = e.id_exame
+            AND q2.id_modulo = e.id_modulo
+        ), 0) AS tentativas_modulo_atual
+      FROM usuarios u
+      LEFT JOIN exames e ON e.id_usuario = u.id_usuario
+      LEFT JOIN modulos m ON m.id_modulo = e.id_modulo
+      ORDER BY u.nome ASC
+    `);
+    return res.status(200).json(result.rows);
+  } catch (error) {
+    console.error("Erro ao listar progresso:", error);
+    return res.status(500).json({ message: "Erro interno ao listar progresso" });
+  }
+});
+
+// Zera tentativas do módulo atual: apaga respostas do módulo e reseta tentativa para 1
+router.patch("/usuarios/:id/zerar-modulo", async (req, res) => {
+  try {
+    const pool = require("../database/db");
+    const idUsuario = Number(req.params.id);
+    if (!idUsuario) return res.status(400).json({ message: "id inválido" });
+
+    const exameRes = await pool.query(
+      `SELECT id_exame, id_modulo FROM exames WHERE id_usuario = $1 ORDER BY id_exame DESC LIMIT 1`,
+      [idUsuario]
+    );
+    if (!exameRes.rows[0]) return res.status(404).json({ message: "Exame não encontrado" });
+
+    const { id_exame, id_modulo } = exameRes.rows[0];
+
+    await pool.query(
+      `DELETE FROM respostas
+       WHERE id_exame = $1
+         AND id_questao IN (SELECT id_questao FROM questoes WHERE id_modulo = $2)`,
+      [id_exame, id_modulo]
+    );
+
+    await pool.query(`UPDATE exames SET tentativa = 1 WHERE id_exame = $1`, [id_exame]);
+
+    return res.status(200).json({ message: "Tentativas do módulo zeradas com sucesso" });
+  } catch (error) {
+    console.error("Erro ao zerar módulo:", error);
+    return res.status(500).json({ message: "Erro interno" });
+  }
+});
+
+// Reinicia completamente: apaga todas as respostas e volta ao Módulo 1
+router.patch("/usuarios/:id/reiniciar", async (req, res) => {
+  try {
+    const pool = require("../database/db");
+    const idUsuario = Number(req.params.id);
+    if (!idUsuario) return res.status(400).json({ message: "id inválido" });
+
+    const exameRes = await pool.query(
+      `SELECT id_exame FROM exames WHERE id_usuario = $1 ORDER BY id_exame DESC LIMIT 1`,
+      [idUsuario]
+    );
+    if (!exameRes.rows[0]) return res.status(404).json({ message: "Exame não encontrado" });
+
+    const { id_exame } = exameRes.rows[0];
+
+    await pool.query(`DELETE FROM respostas WHERE id_exame = $1`, [id_exame]);
+
+    const grupoRes = await pool.query(
+      `SELECT grupo FROM questoes WHERE id_modulo = 1 AND grupo IS NOT NULL GROUP BY grupo ORDER BY grupo LIMIT 1`
+    );
+    const grupo = grupoRes.rows[0]?.grupo || 1;
+
+    await pool.query(
+      `UPDATE exames SET id_modulo = 1, grupo = $1, tentativa = 1 WHERE id_exame = $2`,
+      [grupo, id_exame]
+    );
+
+    return res.status(200).json({ message: "Usuário reiniciado para o Módulo 1 com sucesso" });
+  } catch (error) {
+    console.error("Erro ao reiniciar usuário:", error);
+    return res.status(500).json({ message: "Erro interno" });
+  }
+});
+
+// ================================
 //   QUESTÕES
 // ================================
 

--- a/app/src/routes/auth.routes.js
+++ b/app/src/routes/auth.routes.js
@@ -30,7 +30,7 @@ router.post("/login", async function (req, res) {
 
     await ensureExameInicial(usuario.id_usuario);
 
-    const token = createToken({ id_usuario: usuario.id_usuario });
+    const token = createToken({ id_usuario: usuario.id_usuario, is_admin: usuario.is_admin === true });
 
     return res.status(200).json({
       token,


### PR DESCRIPTION
…de progresso

## Dashboard
- Cards de módulo agora são clicáveis e navegam direto para o módulo correspondente na página de módulos (cursor pointer + event delegation)
- Corrige exibição de "-1 tentativas restantes" após tentativas extras: passa a mostrar "X tentativas realizadas" (sem limite superior)
- Cap visual de tentativas no painel de módulos: exibe no máximo "2 / 2" independente de quantas revisões extras foram feitas

## Página de Questões
- Fix: "Imagem da questão" não aparece mais em questões sem imagem (imgEl.hidden + CSS [hidden] para sobrescrever display:flex)
- Adiciona referência REF.: {id} no rodapé de cada card de questão para facilitar identificação no banco de dados
- Badge de tentativa mostra "Revisão de conteúdo" quando tentativa > 2 em vez de exibir "Tentativa 3/2" (número impossível)

## Controle de Tentativas (Módulos)
- Quando o aluno esgota as 2 tentativas sem aprovação, o botão "Iniciar avaliação" é substituído por mensagem informando que o limite foi atingido e orientando a entrar em contato com o administrador

## Autenticação
- JWT passa a incluir o campo is_admin no payload
- estaAdmin() no frontend corrigido para ler is_admin (antes usava perfil === 'admin' que nunca existiu no token)

## Painel Admin — Gerenciamento de Progresso
- Novo card "Progresso dos Alunos" na seção de administração de configuracoes.html (visível apenas para admins)
- Modal com tabela listando todos os usuários, módulo atual e tentativas realizadas no módulo
- Botão "Zerar módulo": apaga respostas do módulo atual do aluno e reseta tentativa para 1, permitindo que recomece do início
- Botão "Módulo 1": apaga TODAS as respostas e reposiciona o aluno no Módulo 1 com tentativa 1 (reset completo)
- Ambas as ações pedem confirmação antes de executar
- Novos endpoints em admin.routes.js: GET  /api/admin/usuarios-progresso PATCH /api/admin/usuarios/:id/zerar-modulo PATCH /api/admin/usuarios/:id/reiniciar