### PR TITLE
fix: sincroniza id_questao apos seed de questoes

### DIFF
--- a/app/src/infra/init/07_seed_questoes.sql
+++ b/app/src/infra/init/07_seed_questoes.sql
@@ -165,3 +165,8 @@ DO UPDATE SET
   alternativa_c = EXCLUDED.alternativa_c,
   alternativa_d = EXCLUDED.alternativa_d,
   imagem = EXCLUDED.imagem;
+
+SELECT setval(
+  pg_get_serial_sequence('questoes', 'id_questao'),
+  (SELECT COALESCE(MAX(id_questao), 1) FROM questoes)
+);


### PR DESCRIPTION
# Correção do cadastro de questões na área administrativa

## Descrição

Esta correção resolve uma falha no cadastro de novas questões pela área administrativa. Após a atualização/migração do banco de dados, a sequência responsável pela geração automática do campo `id_questao` ficou desincronizada, fazendo com que o sistema tentasse reutilizar identificadores já existentes e retornasse erro de chave duplicada (`questoes_pkey`).

## Alterações realizadas

* Ajuste da sequência utilizada pela tabela `questoes`.
* Garantia de geração correta de novos identificadores para questões cadastradas por administradores.
* Validação do fluxo completo de cadastro pela interface administrativa.

## Resultado

Após a correção, usuários com perfil administrativo conseguem cadastrar novas questões normalmente através da área administrativa, sem ocorrência de erros de chave duplicada no banco de dados.
