### PR TITLE
Feature/s3 t59 toggle lista questoes

### DIFF
--- a/app/public/assets/js/configuracoes.js
+++ b/app/public/assets/js/configuracoes.js
@@ -171,6 +171,8 @@
   const btnSalvarQuestao = formNovaQuestao
     ? formNovaQuestao.querySelector('button[type="submit"]')
     : null;
+  const btnToggleQuestoes = document.getElementById("btn-toggle-questoes");
+  const questoesListaWrapper = document.getElementById("questoes-lista-wrapper");
   let questaoEmEdicaoId = null;
 
   if (btnNovaQuestao && formWrapper) {
@@ -182,6 +184,15 @@
       }
 
       formWrapper.hidden = !formWrapper.hidden;
+    });
+  }
+
+  if (btnToggleQuestoes && questoesListaWrapper) {
+    btnToggleQuestoes.addEventListener("click", function () {
+      questoesListaWrapper.hidden = !questoesListaWrapper.hidden;
+      btnToggleQuestoes.textContent = questoesListaWrapper.hidden
+        ? "Ver questões cadastradas"
+        : "Ocultar questões cadastradas";
     });
   }
 

--- a/app/public/pages/configuracoes.html
+++ b/app/public/pages/configuracoes.html
@@ -472,8 +472,16 @@
               </form>
             </div>
 
+            <button
+              type="button"
+              class="btn btn-ghost"
+              id="btn-toggle-questoes"
+            >
+              Ver questões cadastradas
+            </button>
+
             <!-- Tabela de questões -->
-            <div class="config-tabela-wrapper">
+            <div class="config-tabela-wrapper" id="questoes-lista-wrapper" hidden>
               <table class="config-tabela">
                 <thead>
                   <tr>


### PR DESCRIPTION
# Melhoria da visualização da lista de questões na área administrativa

## Descrição

Esta atualização melhora a experiência de uso da área administrativa ao tornar a lista de questões recolhível. Anteriormente, todas as questões cadastradas eram exibidas diretamente na página, o que dificultava a navegação conforme a quantidade de registros aumentava.

## Alterações realizadas

* Adicionado botão para exibir e ocultar a lista de questões cadastradas.
* Configuração da tabela para iniciar oculta.
* Implementação da alternância de visualização sem impacto nas funcionalidades existentes.
* Preservação das funcionalidades de cadastro, edição e exclusão de questões.

## Resultado

A área administrativa passa a apresentar uma interface mais organizada, permitindo que os administradores visualizem a lista de questões apenas quando necessário, reduzindo a poluição visual da página e melhorando a usabilidade do sistema.
